### PR TITLE
lapwing-base.json: added "mafia"

### DIFF
--- a/lapwing-base.json
+++ b/lapwing-base.json
@@ -60409,6 +60409,8 @@
 "PHAEU/TPHAEUS": "mayonnaise",
 "PHAEU/TPHEUPB": "menin",
 "PHAEU/TPEUBG": "mafic",
+"PHAF/KWRA": "mafia",
+"PHAUF/KWRA": "mafia",
 "PHAEU/TRAR/KHAL": "matriarchal",
 "PHAEU/TRAR/KAL": "matriarchal",
 "PHAEU/TRARBG": "matriarch",


### PR DESCRIPTION
PHAF/KWRA

also added the "PHAUF" variant as I found it in the proper nouns dictionary

@aerickt does order of entries in the json matter? I know that tecnically it doesn't but do you want the entries to be sorted in any way?